### PR TITLE
Test webjar and fix flakyness

### DIFF
--- a/.github/workflows/testing.js.yml
+++ b/.github/workflows/testing.js.yml
@@ -2,6 +2,19 @@ name: Testing
 on:
   push:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      useRealFrontend:
+        description: If true, visit the front-end that is available in ibis-ladybug
+        type: boolean
+        default: false
+        required: true
+      frontendCommitToCheckout:
+        description: Tag or branch of ladybug-frontend to check out
+        required: false
+      backendCommitToCheckout:
+        description: Tag or branch of the backend to test against
+        required: false
 
 jobs:
   testing:
@@ -13,7 +26,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ladybug-frontend
-
+      - name: Fetch all tags
+        if:  ${{ github.event.inputs.frontendCommitToCheckout }}
+        run: git fetch --all --tags
+        working-directory: 'ladybug-frontend'
+      - name: Checkout required version
+        if: ${{ github.event.inputs.frontendCommitToCheckout }}
+        run: git checkout ${{ github.event.inputs.frontendCommitToCheckout }}
+        working-directory: 'ladybug-frontend'
       - name: Use Node.js 16.x
         uses: actions/setup-node@v2
         with:
@@ -82,6 +102,14 @@ jobs:
         with:
           repository: ibissource/ibis-ladybug
           path: ibis-ladybug
+      - name: Fetch all tags of ibis-ladybug
+        if:  ${{ github.event.inputs.backendCommitToCheckout }}
+        run: git fetch --all --tags
+        working-directory: 'ibis-ladybug'
+      - name: Checkout required version of ibis-ladybug
+        if: ${{ github.event.inputs.backendCommitToCheckout }}
+        run: git checkout ${{ github.event.inputs.backendCommitToCheckout }}
+        working-directory: 'ibis-ladybug'
 
       - name: Checkout ibis-ladybug-test-webapp
         uses: actions/checkout@v2
@@ -121,6 +149,7 @@ jobs:
         working-directory: ladybug-frontend
 
       - name: Run cypress with chrome browser
+        if: ${{ ! github.event.inputs.useRealFrontend }}
         uses: cypress-io/github-action@v2.9.7
         with:
           working-directory: ladybug-frontend
@@ -130,6 +159,7 @@ jobs:
           wait-on-timeout: 240
           browser: chrome
       - name: Run cypress with firefox browser
+        if: ${{ ! github.event.inputs.useRealFrontend }}
         uses: cypress-io/github-action@v2.9.7
         with:
           working-directory: ladybug-frontend
@@ -139,6 +169,25 @@ jobs:
           wait-on-timeout: 240
           browser: firefox
           config: screenshotsFolder=cypress/firefox/screenshots,videosFolder=cypress/firefox/videos
+
+      - name: Run cypress with chrome browser - real frontend
+        if: ${{ github.event.inputs.useRealFrontend }}
+        uses: cypress-io/github-action@v2.9.7
+        with:
+          working-directory: ladybug-frontend
+          wait-on: 'http://localhost:8090'
+          wait-on-timeout: 240
+          browser: chrome
+          config: baseUrl=http://localhost:8090/ladybug/
+      - name: Run cypress with firefox browser - real frontend
+        if: ${{ github.event.inputs.useRealFrontend }}
+        uses: cypress-io/github-action@v2.9.7
+        with:
+          working-directory: ladybug-frontend
+          wait-on: 'http://localhost:8090'
+          wait-on-timeout: 240
+          browser: firefox
+          config: baseUrl=http://localhost:8090/ladybug/,screenshotsFolder=cypress/firefox/screenshots,videosFolder=cypress/firefox/videos
 
       - name: Show files
         run: tree -d -L 5 .

--- a/cypress/integration/copying.spec.js
+++ b/cypress/integration/copying.spec.js
@@ -26,9 +26,8 @@ describe('Tests about copying', function() {
     cy.get('button#CopyButton').click();
     cy.get('li#testTab').click();
     // We test that the user does not have to refresh here.
-    cy.get('tbody#testReports').find('tr').should('have.length', 1).within(function(testReport) {
-      cy.wrap(testReport).contains('/name').should('have.length', 1);
-    });
+    cy.get('tbody#testReports').find('tr').should('have.length', 1);
+    cy.get('tbody#testReports').find('tr').contains('/name').should('have.length', 1);
     cy.get('#debugTab').click();
     cy.get('#metadataTable tbody', {timeout: 10000}).find('tr').should('have.length', 2);
     cy.get('div.treeview > ul > li').should('have.length', 6);
@@ -37,8 +36,7 @@ describe('Tests about copying', function() {
     cy.get('div.treeview > ul > li.node-selected').should('have.length', 1);
     cy.get('li#testTab').click();
     // Do not refresh. The test tab should have saved its state.
-    cy.get('tbody#testReports').find('tr').should('have.length', 1).within(function(testReport) {
-      cy.wrap(testReport).contains('/name').should('have.length', 1);
-    });
+    cy.get('tbody#testReports').find('tr').should('have.length', 1);
+    cy.get('tbody#testReports').find('tr').contains('/name').should('have.length', 1);
   });
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "cypress:run": "cypress run",
     "e2e": "start-server-and-test 'ng serve' 4200 cypress:run",
     "e2e-interactive": "start-server-and-test 'ng serve' 4200 cypress:open",
+    "e2e-interactive-webjar": "cypress open --config baseUrl=http://localhost/ladybug/",
+    "e2e-webjar": "cypress run --config baseUrl=http://localhost/ladybug/",
     "lint": "ng lint",
     "prepare": "husky install",
     "startServer": "cd ../frank-runner/specials/ibis-ladybug && ./restart.sh > serverStartLog.log"


### PR DESCRIPTION
I tested the following:

* Na toevoegen argumenten werkt de default test nog - ng serve gebruiken en geen andere versies uitchecken.
* Mergen naar mhdirkse/master. Check dat je handmatig kunt gaan triggeren.
* Vul een willekeurige backend versie in - check in de output dat die wordt uitgechecked.
* Vul een willekeurige tag in van de front-end - check dat die wordt uitgechecked.
* Vul in dat webjars gebruikt moeten worden - check dat dat gebeurt